### PR TITLE
NGC-2974 Upgrade libraries as a security precaution

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,9 +9,9 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc" %% "govuk-template" % "5.18.0",
-    "uk.gov.hmrc" %% "play-ui" % "7.13.0",
+    "uk.gov.hmrc" %% "play-ui" % "7.14.0",
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-25" % "1.4.0"
+    "uk.gov.hmrc" %% "bootstrap-play-25" % "1.5.0"
   )
 
   val test: Seq[ModuleID] = testCommon("test")


### PR DESCRIPTION
Only a precaution because this service does not use ContinueUrl which is what was fixed in the latest play-ui release.

Upgrade bootstrap-play-25 just to stay current (not part of NGC-2974).