### PR TITLE
[NGC-4762] I've added a `/pay-in` endpoint that will redirect to the …

### DIFF
--- a/app/uk/gov/hmrc/mobilehelptosavefrontend/config/GuiceModule.scala
+++ b/app/uk/gov/hmrc/mobilehelptosavefrontend/config/GuiceModule.scala
@@ -24,6 +24,7 @@ class GuiceModule(environment: Environment, configuration: Configuration) extend
 
   override def configure(): Unit = {
     bindConfigString("helpToSave.accessAccountUrl")
+    bindConfigString("helpToSave.accountPayInUrl")
   }
 
   private def bindConfigString(path: String): Unit = {

--- a/app/uk/gov/hmrc/mobilehelptosavefrontend/controllers/SsoWorkaroundController.scala
+++ b/app/uk/gov/hmrc/mobilehelptosavefrontend/controllers/SsoWorkaroundController.scala
@@ -27,16 +27,19 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class SsoWorkaroundController @Inject()(
-  override val authConnector: AuthConnector,
+  override val authConnector:                             AuthConnector,
   @Named("helpToSave.accessAccountUrl") accessAccountUrl: String,
-  override val controllerComponents: MessagesControllerComponents
+  @Named("helpToSave.accountPayInUrl") accountPayInUrl:   String,
+  override val controllerComponents:                      MessagesControllerComponents
 )(
-  implicit ec:ExecutionContext
-) extends FrontendController(controllerComponents) with AuthorisedFunctions {
+  implicit ec: ExecutionContext
+) extends FrontendController(controllerComponents)
+    with AuthorisedFunctions {
 
   val accessAccount: Action[AnyContent] = ssoWorkaround(accessAccountUrl)
+  val payIn:         Action[AnyContent] = ssoWorkaround(accountPayInUrl)
 
-  private def ssoWorkaround(redirectToUrl: String) = Action.async { implicit request =>
+  private def ssoWorkaround(redirectToUrl: String): Action[AnyContent] = Action.async { implicit request =>
     val redirect: Result = Redirect(redirectToUrl)
 
     authorised().retrieve(Retrievals.affinityGroup) {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,4 @@
 # microservice specific routes
 
-GET        /access-account             uk.gov.hmrc.mobilehelptosavefrontend.controllers.SsoWorkaroundController.accessAccount
+GET        /access-account        uk.gov.hmrc.mobilehelptosavefrontend.controllers.SsoWorkaroundController.accessAccount
+GET        /pay-in                uk.gov.hmrc.mobilehelptosavefrontend.controllers.SsoWorkaroundController.payIn

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -14,8 +14,8 @@
 
 include "frontend.conf"
 
-appName="mobile-help-to-save-frontend"
-application.router=prod.Routes
+appName = "mobile-help-to-save-frontend"
+application.router = prod.Routes
 
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
@@ -43,7 +43,7 @@ play.modules.enabled += "uk.gov.hmrc.mobilehelptosavefrontend.config.GuiceModule
 # Custom error handler
 play.http.errorHandler = "uk.gov.hmrc.mobilehelptosavefrontend.config.ErrorHandler"
 
-play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com data:"
+play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com data:"
 
 # Play Modules
 # ~~~~
@@ -113,4 +113,5 @@ contact-frontend {
 
 helpToSave {
   accessAccountUrl = "http://localhost:7000/help-to-save/access-account"
+  accountPayInUrl = "http://localhost:7000/help-to-save/pay-in"
 }

--- a/it/uk/gov/hmrc/mobilehelptosavefrontend/SsoWorkaroundISpec.scala
+++ b/it/uk/gov/hmrc/mobilehelptosavefrontend/SsoWorkaroundISpec.scala
@@ -38,8 +38,11 @@ class SsoWorkaroundISpec
     with OneServerPerSuiteWsClient {
 
   private val configuredAccessAccountUrl = "http://example.com/test-help-to-save/access-account"
+  private val configuredAccountPayInUrl  = "http://example.com/test-help-to-save/pay-in"
+
   override implicit lazy val app: Application = wireMockApplicationBuilder()
     .configure("helpToSave.accessAccountUrl" -> configuredAccessAccountUrl)
+    .configure("helpToSave.accountPayInUrl" -> configuredAccountPayInUrl)
     .build()
 
   private lazy val sessionCrypto     = app.injector.instanceOf[SessionCookieCrypto]
@@ -47,6 +50,10 @@ class SsoWorkaroundISpec
 
   "GET /mobile-help-to-save/access-account" should {
     behave like anSsoWorkaroundEndpoint(withUrl = "/mobile-help-to-save/access-account", redirectingToUrl = configuredAccessAccountUrl)
+  }
+
+  "GET /mobile-help-to-save/pay-in" should {
+    behave like anSsoWorkaroundEndpoint(withUrl = "/mobile-help-to-save/pay-in", redirectingToUrl = configuredAccountPayInUrl)
   }
 
   private def anSsoWorkaroundEndpoint(withUrl: String, redirectingToUrl: String): Unit = {

--- a/test/uk/gov/hmrc/mobilehelptosavefrontend/controllers/SsoWorkaroundControllerSpec.scala
+++ b/test/uk/gov/hmrc/mobilehelptosavefrontend/controllers/SsoWorkaroundControllerSpec.scala
@@ -31,6 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SsoWorkaroundControllerSpec extends WordSpec with Matchers with FutureAwaits with DefaultAwaitTimeout {
 
   private val configuredAccessAccountUrl = "/help-to-save/access-account"
+  private val configuredAccountPayInUrl  = "/help-to-save/access-account"
 
   private val messagesActionBuilder: MessagesActionBuilder = new DefaultMessagesActionBuilderImpl(stubBodyParser[AnyContent](), stubMessagesApi())
   private val cc = stubControllerComponents()
@@ -60,8 +61,12 @@ class SsoWorkaroundControllerSpec extends WordSpec with Matchers with FutureAwai
           }
       }
 
-      val controller = new SsoWorkaroundController(fakeAuthConnector, accessAccountUrl = configuredAccessAccountUrl, mcc)
-      val action     = getAction(controller)
+      val controller = new SsoWorkaroundController(
+        fakeAuthConnector,
+        accessAccountUrl = configuredAccessAccountUrl,
+        accountPayInUrl  = configuredAccountPayInUrl,
+        mcc)
+      val action = getAction(controller)
 
       implicit val request: Request[AnyContentAsEmpty.type] = FakeRequest()
       val result:           Result                          = await(action(request))
@@ -79,8 +84,12 @@ class SsoWorkaroundControllerSpec extends WordSpec with Matchers with FutureAwai
             case _                        => ???
           }
       }
-      val controller = new SsoWorkaroundController(fakeAuthConnector, accessAccountUrl = configuredAccessAccountUrl, mcc)
-      val action     = getAction(controller)
+      val controller = new SsoWorkaroundController(
+        fakeAuthConnector,
+        accessAccountUrl = configuredAccessAccountUrl,
+        accountPayInUrl  = configuredAccountPayInUrl,
+        mcc)
+      val action = getAction(controller)
 
       implicit val request: Request[AnyContentAsEmpty.type] = FakeRequest().withSession(SessionKeys.affinityGroup -> "OldAffinityGroupInSession")
       val result:           Result                          = await(action(request))
@@ -95,8 +104,12 @@ class SsoWorkaroundControllerSpec extends WordSpec with Matchers with FutureAwai
         override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
           Future failed new NoActiveSession("not logged in") {}
       }
-      val controller = new SsoWorkaroundController(fakeAuthConnector, accessAccountUrl = configuredAccessAccountUrl, mcc)
-      val action     = getAction(controller)
+      val controller = new SsoWorkaroundController(
+        fakeAuthConnector,
+        accessAccountUrl = configuredAccessAccountUrl,
+        accountPayInUrl  = configuredAccountPayInUrl,
+        mcc)
+      val action = getAction(controller)
 
       val result: Result = await(action(FakeRequest()))
 


### PR DESCRIPTION
…configured url to take the user directly to the payments page on `help-to-save`.